### PR TITLE
chore: update social icons and footer links in the website template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Timothy Lin
+Copyright (c) 2024 tanhiep
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,12 +9,7 @@ export default function Footer() {
         <div className="mb-3 flex space-x-4">
           <SocialIcon kind="mail" href={`mailto:${siteMetadata.email}`} size={6} />
           <SocialIcon kind="github" href={siteMetadata.github} size={6} />
-          <SocialIcon kind="facebook" href={siteMetadata.facebook} size={6} />
-          <SocialIcon kind="youtube" href={siteMetadata.youtube} size={6} />
           <SocialIcon kind="linkedin" href={siteMetadata.linkedin} size={6} />
-          <SocialIcon kind="twitter" href={siteMetadata.twitter} size={6} />
-          <SocialIcon kind="instagram" href={siteMetadata.instagram} size={6} />
-          <SocialIcon kind="threads" href={siteMetadata.threads} size={6} />
         </div>
         <div className="mb-2 flex space-x-2 text-sm text-gray-500 dark:text-gray-400">
           <div>{siteMetadata.author}</div>
@@ -23,8 +18,10 @@ export default function Footer() {
           <div>{` • `}</div>
           <Link href="/">{siteMetadata.title}</Link>
         </div>
-        <div className="mb-8 border-gray-400 text-sm text-gray-400 hover:border-b-2 ">
-          <Link href="https://github.com/centopw">Made With ❤ by Tanhiep</Link>
+        <div className="mb-8 border-b-2 border-transparent text-sm text-gray-400 hover:border-gray-400">
+          <Link className="font-bold " href={siteMetadata.siteRepo}>
+            This site is open source on GitHub!
+          </Link>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
The social icons for Facebook, YouTube, Twitter, Instagram, and Threads have been removed from the footer. Additionally, the link "Made With ❤ by Tanhiep" has been replaced with a link to the GitHub repository of the site.