### PR TITLE
feat: add @vercel/speed-insights package for performance optimization

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ import Footer from '@/components/Footer'
 import siteMetadata from '@/data/siteMetadata'
 import { ThemeProviders } from './theme-providers'
 import { Metadata } from 'next'
-
+import { SpeedInsights } from '@vercel/speed-insights/next'
 const space_grotesk = Space_Grotesk({
   subsets: ['latin'],
   display: 'swap',

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tiptap/pm": "^2.1.16",
     "@tiptap/react": "^2.1.16",
     "@tiptap/starter-kit": "^2.1.16",
+    "@vercel/speed-insights": "^1.0.10",
     "autoprefixer": "^10.4.13",
     "contentlayer": "0.3.4",
     "esbuild": "0.18.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3809,6 +3809,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/speed-insights@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "@vercel/speed-insights@npm:1.0.10"
+  peerDependencies:
+    "@sveltejs/kit": ^1 || ^2
+    next: ">= 13"
+    react: ^18 || ^19
+    svelte: ^4
+    vue: ^3
+    vue-router: ^4
+  peerDependenciesMeta:
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    react:
+      optional: true
+    svelte:
+      optional: true
+    vue:
+      optional: true
+    vue-router:
+      optional: true
+  checksum: 26171c424ed725bbb82020818428a37e54715dfba58ae8ccff53c1bb58787f3713a9d8695afbbb5439555b92614f099fdb5188f80d9855818fddf7c192e8033e
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^2.0.0":
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
@@ -11564,6 +11591,7 @@ __metadata:
     "@types/react": ^18.2.14
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
+    "@vercel/speed-insights": ^1.0.10
     autoprefixer: ^10.4.13
     contentlayer: 0.3.4
     cross-env: ^7.0.3


### PR DESCRIPTION
The commit adds the "@vercel/speed-insights" package to the project's dependencies. This package is used for performance optimization and speed insights. It will help analyze and improve the performance of the website.